### PR TITLE
Provide hosts as settings and add npm run start script

### DIFF
--- a/config/settings.defaults.coffee
+++ b/config/settings.defaults.coffee
@@ -1,20 +1,20 @@
 module.exports =
 	internal:
 		chat:
-			host: "localhost"
+			host: process.env['LISTEN_ADDRESS'] or "localhost"
 			port: 3010
 	
 	apis:
 		web:
-			url: "http://localhost:3000"
+			url: "http://#{process.env['WEB_HOST'] || "localhost"}:3000"
 			user: "sharelatex"
 			pass: "password"
 			
 	mongo:
-		url : 'mongodb://127.0.0.1/sharelatex'
+		url : "mongodb://#{process.env['MONGO_HOST'] || "localhost"}/sharelatex"
 
 	redis:
 		web:
-			host: "localhost"
+			host: process.env['REDIS_HOST'] || "localhost"
 			port: "6379"
 			password: ""

--- a/package.json
+++ b/package.json
@@ -6,6 +6,10 @@
     "type": "git",
     "url": "https://github.com/sharelatex/chat-sharelatex.git"
   },
+  "scripts": {
+    "compile:app": "coffee -o app/js -c app/coffee && coffee -c app.coffee",
+    "start": "npm run compile:app && node app.js"
+  },
   "dependencies": {
     "async": "0.2.9",
     "coffee-script": "~1.7.1",


### PR DESCRIPTION
Makes this service compatible with https://github.com/sharelatex/sharelatex-dev-environment

Allows other service's locations to be passed in via environment variables which are provided by docker-compose.

Also provides an `npm run start` script as a common entry point to all services via docker-compose.

Connects to https://github.com/overleaf/sharelatex/issues/305