### PR TITLE
Switch dev env to use v2 instead of SL

### DIFF
--- a/config/settings.defaults.coffee
+++ b/config/settings.defaults.coffee
@@ -6,7 +6,7 @@ module.exports =
 	
 	apis:
 		web:
-			url: "http://#{process.env['WEB_HOST'] || "localhost"}:3000"
+			url: "http://#{process.env['WEB_HOST'] || "localhost"}:#{process.env['WEB_PORT'] or 3000}"
 			user: "sharelatex"
 			pass: "password"
 			


### PR DESCRIPTION
### Description

Switches dev environment to use web_v2 container instead of web_sl container now that the SL container is not needed in most dev workflows.

#### Related Issues / PRs

Connects to https://github.com/sharelatex/sharelatex-dev-environment/issues/121