### PR TITLE
Use correct git tag for settings-sharelatex repository

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -7341,7 +7341,7 @@
     },
     "settings-sharelatex": {
       "version": "git+https://github.com/sharelatex/settings-sharelatex.git#93f63d029b52fef8825c3a401b2b6a7ba29b4750",
-      "from": "git+https://github.com/sharelatex/settings-sharelatex.git#1.1.0",
+      "from": "git+https://github.com/sharelatex/settings-sharelatex.git#v1.1.0",
       "requires": {
         "coffee-script": "1.6.0"
       },

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "mongojs": "2.4.0",
     "redis": "~0.10.1",
     "request": "^2.79.0",
-    "settings-sharelatex": "git+https://github.com/sharelatex/settings-sharelatex.git#1.1.0",
+    "settings-sharelatex": "git+https://github.com/sharelatex/settings-sharelatex.git#v1.1.0",
     "v8-profiler": "^5.6.5"
   },
   "devDependencies": {


### PR DESCRIPTION
### Description

`bin/install` was not working for me. It would hang with:

```
npm ERR! git rev-list -n1 1.1.0: fatal: ambiguous argument '1.1.0': unknown revision or path not in the working tree.
npm ERR! git rev-list -n1 1.1.0: Use '--' to separate paths from revisions, like this:
npm ERR! git rev-list -n1 1.1.0: 'git <command> [<revision>...] -- [<file>...]'
npm ERR! git rev-list -n1 1.1.0: 
[   ...............] | cloneCurrentTree: sill gunzTarPerm extractEntry
```

This command would hang forever until I killed the container with `docker rm -f`. Ctrl+C was not sufficient.

Looks like the error was caused by an incorrect git tag reference in package.json/npm-shrinkwrap.json, pointing to tag `1.1.0` instead of `v1.1.0`. I looked around and saw that this is what has happened in other places, so I'm not sure how this has worked before. ¯\\\_(ツ)\_/¯

### Review

It builds just fine after I make this change.

#### Potential Impact

Dev environment. Builds.

#### Manual Testing Performed

- [x] Ran `bin/install` successfully
