### PR TITLE
Update Build Scripts to 1.1.16

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -35,6 +35,11 @@ pipeline {
         sh 'make build'
       }
     }
+    stage('Linting') {
+      steps {
+        sh 'DOCKER_COMPOSE_FLAGS="-f docker-compose.ci.yml" make lint'
+      }
+    }
 
     stage('Unit Tests') {
       steps {

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # This file was auto-generated, do not edit it directly.
 # Instead run bin/update_build_scripts from
 # https://github.com/sharelatex/sharelatex-dev-environment
-# Version: 1.1.12
+# Version: 1.1.16
 
 BUILD_NUMBER ?= local
 BRANCH_NAME ?= $(shell git rev-parse --abbrev-ref HEAD)
@@ -24,7 +24,9 @@ test: lint test_unit test_acceptance
 test_unit:
 	@[ ! -d test/unit ] && echo "chat has no unit tests" || $(DOCKER_COMPOSE) run --rm test_unit
 
-test_acceptance: test_clean test_acceptance_pre_run # clear the database before each acceptance test run
+test_acceptance: test_clean test_acceptance_pre_run test_acceptance_run
+
+test_acceptance_run:
 	@[ ! -d test/acceptance ] && echo "chat has no acceptance tests" || $(DOCKER_COMPOSE) run --rm test_acceptance
 
 test_clean:

--- a/buildscript.txt
+++ b/buildscript.txt
@@ -5,4 +5,4 @@ chat
 --dependencies=mongo,redis
 --docker-repos=gcr.io/overleaf-ops
 --build-target=docker
---script-version=1.1.12
+--script-version=1.1.16

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -1,9 +1,9 @@
 # This file was auto-generated, do not edit it directly.
 # Instead run bin/update_build_scripts from
 # https://github.com/sharelatex/sharelatex-dev-environment
-# Version: 1.1.12
+# Version: 1.1.16
 
-version: "2"
+version: "3.1"
 
 services:
   test_unit:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,13 +1,13 @@
 # This file was auto-generated, do not edit it directly.
 # Instead run bin/update_build_scripts from
 # https://github.com/sharelatex/sharelatex-dev-environment
-# Version: 1.1.12
+# Version: 1.1.16
 
-version: "2"
+version: "3.1"
 
 services:
   test_unit:
-    build: .
+    image: node:6.14.1
     volumes:
       - .:/app
     working_dir: /app


### PR DESCRIPTION
Not strictly needed, but I wanted to make sure the new Linting step wouldn't break the build.
Should we merge this or park it?