### PR TITLE
[misc] add support for node 8+

### DIFF
--- a/app/js/server.js
+++ b/app/js/server.js
@@ -33,7 +33,7 @@ if (app.get('env') === 'production') {
   app.use(express.errorHandler())
 }
 
-const profiler = require('v8-profiler')
+const profiler = require('v8-profiler-node8')
 app.get('/profile', function(req, res) {
   const time = parseInt(req.query.time || '1000')
   profiler.startProfiling('test')

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -230,8 +230,7 @@
     "abbrev": {
       "version": "1.1.1",
       "from": "abbrev@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz"
     },
     "acorn": {
       "version": "6.1.1",
@@ -291,8 +290,7 @@
     "ansi-regex": {
       "version": "3.0.0",
       "from": "ansi-regex@>=3.0.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz"
     },
     "ansi-styles": {
       "version": "3.2.1",
@@ -305,6 +303,16 @@
       "from": "anymatch@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
       "dev": true
+    },
+    "aproba": {
+      "version": "1.2.0",
+      "from": "aproba@>=1.0.3 <2.0.0",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz"
+    },
+    "are-we-there-yet": {
+      "version": "1.1.5",
+      "from": "are-we-there-yet@>=1.1.2 <1.2.0",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz"
     },
     "argparse": {
       "version": "1.0.10",
@@ -688,6 +696,11 @@
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.0.3.tgz",
       "dev": true
     },
+    "chownr": {
+      "version": "1.1.1",
+      "from": "chownr@>=1.1.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz"
+    },
     "ci-info": {
       "version": "1.1.3",
       "from": "ci-info@>=1.0.0 <2.0.0",
@@ -773,8 +786,7 @@
     "code-point-at": {
       "version": "1.1.0",
       "from": "code-point-at@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz"
     },
     "coffee-script": {
       "version": "1.12.4",
@@ -846,6 +858,11 @@
           "dev": true
         }
       }
+    },
+    "console-control-strings": {
+      "version": "1.1.0",
+      "from": "console-control-strings@>=1.1.0 <1.2.0",
+      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz"
     },
     "console-log-level": {
       "version": "1.4.0",
@@ -953,8 +970,7 @@
     "deep-extend": {
       "version": "0.5.1",
       "from": "deep-extend@>=0.5.1 <0.6.0",
-      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.5.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.5.1.tgz"
     },
     "deep-is": {
       "version": "0.1.3",
@@ -1003,6 +1019,16 @@
       "version": "1.0.0",
       "from": "delayed-stream@>=1.0.0 <1.1.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
+    },
+    "delegates": {
+      "version": "1.0.0",
+      "from": "delegates@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz"
+    },
+    "detect-libc": {
+      "version": "1.0.3",
+      "from": "detect-libc@>=1.0.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz"
     },
     "diff": {
       "version": "3.5.0",
@@ -1686,11 +1712,15 @@
       "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
       "dev": true
     },
+    "fs-minipass": {
+      "version": "1.2.5",
+      "from": "fs-minipass@>=1.2.5 <2.0.0",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz"
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "from": "fs.realpath@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
     },
     "function-bind": {
       "version": "1.1.1",
@@ -1703,6 +1733,33 @@
       "from": "functional-red-black-tree@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "dev": true
+    },
+    "gauge": {
+      "version": "2.7.4",
+      "from": "gauge@>=2.7.3 <2.8.0",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "from": "ansi-regex@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "from": "is-fullwidth-code-point@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz"
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "from": "string-width@>=1.0.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz"
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "from": "strip-ansi@>=3.0.1 <4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
+        }
+      }
     },
     "gaxios": {
       "version": "1.2.7",
@@ -1751,8 +1808,7 @@
     "glob": {
       "version": "7.1.3",
       "from": "glob@>=7.1.2 <8.0.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz"
     },
     "glob-parent": {
       "version": "3.1.0",
@@ -1876,6 +1932,11 @@
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
       "dev": true
     },
+    "has-unicode": {
+      "version": "2.0.1",
+      "from": "has-unicode@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz"
+    },
     "has-value": {
       "version": "1.0.0",
       "from": "has-value@>=1.0.0 <2.0.0",
@@ -1926,8 +1987,7 @@
     "iconv-lite": {
       "version": "0.4.24",
       "from": "iconv-lite@>=0.4.24 <0.5.0",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz"
     },
     "ignore": {
       "version": "4.0.6",
@@ -1940,6 +2000,11 @@
       "from": "ignore-by-default@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
       "dev": true
+    },
+    "ignore-walk": {
+      "version": "3.0.1",
+      "from": "ignore-walk@>=3.0.1 <4.0.0",
+      "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz"
     },
     "import-fresh": {
       "version": "3.0.0",
@@ -1978,8 +2043,7 @@
     "ini": {
       "version": "1.3.5",
       "from": "ini@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz"
     },
     "inquirer": {
       "version": "6.2.2",
@@ -2110,8 +2174,7 @@
     "is-fullwidth-code-point": {
       "version": "2.0.0",
       "from": "is-fullwidth-code-point@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz"
     },
     "is-glob": {
       "version": "4.0.0",
@@ -2644,13 +2707,29 @@
     "minimatch": {
       "version": "3.0.4",
       "from": "minimatch@>=3.0.4 <4.0.0",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz"
     },
     "minimist": {
       "version": "0.0.8",
       "from": "minimist@0.0.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+    },
+    "minipass": {
+      "version": "2.3.5",
+      "from": "minipass@>=2.3.4 <3.0.0",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
+      "dependencies": {
+        "yallist": {
+          "version": "3.0.3",
+          "from": "yallist@^3.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz"
+        }
+      }
+    },
+    "minizlib": {
+      "version": "1.2.1",
+      "from": "minizlib@>=1.1.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.2.1.tgz"
     },
     "mixin-deep": {
       "version": "1.3.1",
@@ -2955,8 +3034,7 @@
     "nan": {
       "version": "2.10.0",
       "from": "nan@>=2.3.3 <3.0.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
-      "optional": true
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz"
     },
     "nanomatch": {
       "version": "1.2.9",
@@ -2975,6 +3053,23 @@
       "from": "ncp@>=2.0.0 <2.1.0",
       "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
       "optional": true
+    },
+    "needle": {
+      "version": "2.3.1",
+      "from": "needle@>=2.2.1 <3.0.0",
+      "resolved": "https://registry.npmjs.org/needle/-/needle-2.3.1.tgz",
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "from": "debug@>=4.1.0 <5.0.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz"
+        },
+        "ms": {
+          "version": "2.1.1",
+          "from": "ms@>=2.1.1 <3.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz"
+        }
+      }
     },
     "nice-try": {
       "version": "1.0.5",
@@ -2996,6 +3091,18 @@
       "version": "0.7.6",
       "from": "node-forge@>=0.7.5 <0.8.0",
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.6.tgz"
+    },
+    "node-pre-gyp": {
+      "version": "0.11.0",
+      "from": "node-pre-gyp@>=0.11.0 <0.12.0",
+      "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.11.0.tgz",
+      "dependencies": {
+        "nopt": {
+          "version": "4.0.1",
+          "from": "nopt@>=4.0.1 <5.0.0",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz"
+        }
+      }
     },
     "nodemon": {
       "version": "1.17.4",
@@ -3041,17 +3148,31 @@
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
       "dev": true
     },
+    "npm-bundled": {
+      "version": "1.0.6",
+      "from": "npm-bundled@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.6.tgz"
+    },
+    "npm-packlist": {
+      "version": "1.4.1",
+      "from": "npm-packlist@>=1.1.6 <2.0.0",
+      "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.1.tgz"
+    },
     "npm-run-path": {
       "version": "2.0.2",
       "from": "npm-run-path@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
       "dev": true
     },
+    "npmlog": {
+      "version": "4.1.2",
+      "from": "npmlog@>=4.0.2 <5.0.0",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz"
+    },
     "number-is-nan": {
       "version": "1.0.1",
       "from": "number-is-nan@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
     },
     "oauth-sign": {
       "version": "0.9.0",
@@ -3061,8 +3182,7 @@
     "object-assign": {
       "version": "4.1.1",
       "from": "object-assign@>=4.1.1 <5.0.0",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
     },
     "object-copy": {
       "version": "0.1.0",
@@ -3125,6 +3245,11 @@
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
       "dev": true
     },
+    "os-homedir": {
+      "version": "1.0.2",
+      "from": "os-homedir@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz"
+    },
     "os-locale": {
       "version": "2.1.0",
       "from": "os-locale@>=2.0.0 <3.0.0",
@@ -3134,8 +3259,12 @@
     "os-tmpdir": {
       "version": "1.0.2",
       "from": "os-tmpdir@>=1.0.2 <1.1.0",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz"
+    },
+    "osenv": {
+      "version": "0.1.5",
+      "from": "osenv@>=0.1.4 <0.2.0",
+      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz"
     },
     "p-finally": {
       "version": "1.0.0",
@@ -3732,13 +3861,11 @@
       "version": "1.2.7",
       "from": "rc@>=1.1.6 <2.0.0",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.7.tgz",
-      "dev": true,
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
           "from": "minimist@>=1.2.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
         }
       }
     },
@@ -4225,8 +4352,7 @@
     "rimraf": {
       "version": "2.6.3",
       "from": "rimraf@2.6.3",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz"
     },
     "run-async": {
       "version": "2.3.0",
@@ -4284,6 +4410,11 @@
       "from": "sandboxed-module@latest",
       "resolved": "https://registry.npmjs.org/sandboxed-module/-/sandboxed-module-2.0.3.tgz"
     },
+    "sax": {
+      "version": "1.2.4",
+      "from": "sax@>=1.2.4 <2.0.0",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz"
+    },
     "semver": {
       "version": "5.6.0",
       "from": "semver@>=5.5.0 <6.0.0",
@@ -4306,8 +4437,7 @@
     "set-blocking": {
       "version": "2.0.0",
       "from": "set-blocking@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz"
     },
     "set-immediate-shim": {
       "version": "1.0.1",
@@ -4361,8 +4491,7 @@
     "signal-exit": {
       "version": "3.0.2",
       "from": "signal-exit@>=3.0.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz"
     },
     "sinon": {
       "version": "5.0.7",
@@ -4555,14 +4684,12 @@
     "string-width": {
       "version": "2.1.1",
       "from": "string-width@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz"
     },
     "strip-ansi": {
       "version": "4.0.0",
       "from": "strip-ansi@>=4.0.0 <5.0.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz"
     },
     "strip-bom": {
       "version": "3.0.0",
@@ -4579,8 +4706,7 @@
     "strip-json-comments": {
       "version": "2.0.1",
       "from": "strip-json-comments@>=2.0.1 <2.1.0",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz"
     },
     "supports-color": {
       "version": "5.4.0",
@@ -4621,6 +4747,18 @@
           "from": "strip-ansi@^5.1.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
           "dev": true
+        }
+      }
+    },
+    "tar": {
+      "version": "4.4.8",
+      "from": "tar@>=4.0.0 <5.0.0",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.8.tgz",
+      "dependencies": {
+        "yallist": {
+          "version": "3.0.3",
+          "from": "yallist@>=3.0.2 <4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz"
         }
       }
     },
@@ -4912,672 +5050,10 @@
       "from": "uuid@3.0.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.0.tgz"
     },
-    "v8-profiler": {
-      "version": "5.7.0",
-      "from": "v8-profiler@>=5.6.5 <6.0.0",
-      "resolved": "https://registry.npmjs.org/v8-profiler/-/v8-profiler-5.7.0.tgz",
-      "dependencies": {
-        "nan": {
-          "version": "2.7.0",
-          "from": "nan@>=2.5.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.7.0.tgz"
-        },
-        "node-pre-gyp": {
-          "version": "0.6.37",
-          "from": "node-pre-gyp@>=0.6.34 <0.7.0",
-          "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.37.tgz",
-          "dependencies": {
-            "mkdirp": {
-              "version": "0.5.1",
-              "from": "mkdirp@>=0.5.1 <0.6.0",
-              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-              "dependencies": {
-                "minimist": {
-                  "version": "0.0.8",
-                  "from": "minimist@0.0.8",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
-                }
-              }
-            },
-            "nopt": {
-              "version": "4.0.1",
-              "from": "nopt@>=4.0.1 <5.0.0",
-              "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
-              "dependencies": {
-                "abbrev": {
-                  "version": "1.1.0",
-                  "from": "abbrev@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz"
-                },
-                "osenv": {
-                  "version": "0.1.4",
-                  "from": "osenv@>=0.1.4 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
-                  "dependencies": {
-                    "os-homedir": {
-                      "version": "1.0.2",
-                      "from": "os-homedir@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz"
-                    },
-                    "os-tmpdir": {
-                      "version": "1.0.2",
-                      "from": "os-tmpdir@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "npmlog": {
-              "version": "4.1.2",
-              "from": "npmlog@>=4.0.2 <5.0.0",
-              "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-              "dependencies": {
-                "are-we-there-yet": {
-                  "version": "1.1.4",
-                  "from": "are-we-there-yet@>=1.1.2 <1.2.0",
-                  "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
-                  "dependencies": {
-                    "delegates": {
-                      "version": "1.0.0",
-                      "from": "delegates@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz"
-                    },
-                    "readable-stream": {
-                      "version": "2.3.3",
-                      "from": "readable-stream@>=2.0.6 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-                      "dependencies": {
-                        "core-util-is": {
-                          "version": "1.0.2",
-                          "from": "core-util-is@>=1.0.0 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                        },
-                        "inherits": {
-                          "version": "2.0.3",
-                          "from": "inherits@>=2.0.3 <2.1.0",
-                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
-                        },
-                        "isarray": {
-                          "version": "1.0.0",
-                          "from": "isarray@>=1.0.0 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-                        },
-                        "process-nextick-args": {
-                          "version": "1.0.7",
-                          "from": "process-nextick-args@>=1.0.6 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
-                        },
-                        "safe-buffer": {
-                          "version": "5.1.1",
-                          "from": "safe-buffer@>=5.1.1 <5.2.0",
-                          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
-                        },
-                        "string_decoder": {
-                          "version": "1.0.3",
-                          "from": "string_decoder@>=1.0.3 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz"
-                        },
-                        "util-deprecate": {
-                          "version": "1.0.2",
-                          "from": "util-deprecate@>=1.0.1 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "console-control-strings": {
-                  "version": "1.1.0",
-                  "from": "console-control-strings@>=1.1.0 <1.2.0",
-                  "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz"
-                },
-                "gauge": {
-                  "version": "2.7.4",
-                  "from": "gauge@>=2.7.3 <2.8.0",
-                  "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-                  "dependencies": {
-                    "aproba": {
-                      "version": "1.1.2",
-                      "from": "aproba@>=1.0.3 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.1.2.tgz"
-                    },
-                    "has-unicode": {
-                      "version": "2.0.1",
-                      "from": "has-unicode@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz"
-                    },
-                    "object-assign": {
-                      "version": "4.1.1",
-                      "from": "object-assign@>=4.1.0 <5.0.0",
-                      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
-                    },
-                    "signal-exit": {
-                      "version": "3.0.2",
-                      "from": "signal-exit@>=3.0.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz"
-                    },
-                    "string-width": {
-                      "version": "1.0.2",
-                      "from": "string-width@>=1.0.1 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-                      "dependencies": {
-                        "code-point-at": {
-                          "version": "1.1.0",
-                          "from": "code-point-at@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz"
-                        },
-                        "is-fullwidth-code-point": {
-                          "version": "1.0.0",
-                          "from": "is-fullwidth-code-point@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-                          "dependencies": {
-                            "number-is-nan": {
-                              "version": "1.0.1",
-                              "from": "number-is-nan@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "strip-ansi": {
-                      "version": "3.0.1",
-                      "from": "strip-ansi@>=3.0.1 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                      "dependencies": {
-                        "ansi-regex": {
-                          "version": "2.1.1",
-                          "from": "ansi-regex@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
-                        }
-                      }
-                    },
-                    "wide-align": {
-                      "version": "1.1.2",
-                      "from": "wide-align@>=1.1.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz"
-                    }
-                  }
-                },
-                "set-blocking": {
-                  "version": "2.0.0",
-                  "from": "set-blocking@>=2.0.0 <2.1.0",
-                  "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz"
-                }
-              }
-            },
-            "rc": {
-              "version": "1.2.1",
-              "from": "rc@>=1.1.7 <2.0.0",
-              "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
-              "dependencies": {
-                "deep-extend": {
-                  "version": "0.4.2",
-                  "from": "deep-extend@>=0.4.0 <0.5.0",
-                  "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz"
-                },
-                "ini": {
-                  "version": "1.3.4",
-                  "from": "ini@>=1.3.0 <1.4.0",
-                  "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
-                },
-                "minimist": {
-                  "version": "1.2.0",
-                  "from": "minimist@>=1.2.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
-                },
-                "strip-json-comments": {
-                  "version": "2.0.1",
-                  "from": "strip-json-comments@>=2.0.1 <2.1.0",
-                  "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz"
-                }
-              }
-            },
-            "rimraf": {
-              "version": "2.6.1",
-              "from": "rimraf@>=2.6.1 <3.0.0",
-              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
-              "dependencies": {
-                "glob": {
-                  "version": "7.1.2",
-                  "from": "glob@>=7.0.5 <8.0.0",
-                  "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-                  "dependencies": {
-                    "fs.realpath": {
-                      "version": "1.0.0",
-                      "from": "fs.realpath@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
-                    },
-                    "inflight": {
-                      "version": "1.0.6",
-                      "from": "inflight@>=1.0.4 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-                      "dependencies": {
-                        "wrappy": {
-                          "version": "1.0.2",
-                          "from": "wrappy@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
-                        }
-                      }
-                    },
-                    "inherits": {
-                      "version": "2.0.3",
-                      "from": "inherits@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
-                    },
-                    "minimatch": {
-                      "version": "3.0.4",
-                      "from": "minimatch@>=3.0.4 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-                      "dependencies": {
-                        "brace-expansion": {
-                          "version": "1.1.8",
-                          "from": "brace-expansion@>=1.1.7 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
-                          "dependencies": {
-                            "balanced-match": {
-                              "version": "1.0.0",
-                              "from": "balanced-match@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz"
-                            },
-                            "concat-map": {
-                              "version": "0.0.1",
-                              "from": "concat-map@0.0.1",
-                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "once": {
-                      "version": "1.4.0",
-                      "from": "once@>=1.3.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-                      "dependencies": {
-                        "wrappy": {
-                          "version": "1.0.2",
-                          "from": "wrappy@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
-                        }
-                      }
-                    },
-                    "path-is-absolute": {
-                      "version": "1.0.1",
-                      "from": "path-is-absolute@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "semver": {
-              "version": "5.4.1",
-              "from": "semver@>=5.3.0 <6.0.0",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz"
-            },
-            "tape": {
-              "version": "4.8.0",
-              "from": "tape@>=4.6.3 <5.0.0",
-              "resolved": "https://registry.npmjs.org/tape/-/tape-4.8.0.tgz",
-              "dependencies": {
-                "deep-equal": {
-                  "version": "1.0.1",
-                  "from": "deep-equal@>=1.0.1 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz"
-                },
-                "defined": {
-                  "version": "1.0.0",
-                  "from": "defined@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz"
-                },
-                "for-each": {
-                  "version": "0.3.2",
-                  "from": "for-each@>=0.3.2 <0.4.0",
-                  "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.2.tgz",
-                  "dependencies": {
-                    "is-function": {
-                      "version": "1.0.1",
-                      "from": "is-function@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.1.tgz"
-                    }
-                  }
-                },
-                "function-bind": {
-                  "version": "1.1.1",
-                  "from": "function-bind@>=1.1.0 <1.2.0",
-                  "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz"
-                },
-                "glob": {
-                  "version": "7.1.2",
-                  "from": "glob@>=7.1.2 <7.2.0",
-                  "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-                  "dependencies": {
-                    "fs.realpath": {
-                      "version": "1.0.0",
-                      "from": "fs.realpath@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
-                    },
-                    "inflight": {
-                      "version": "1.0.6",
-                      "from": "inflight@>=1.0.4 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-                      "dependencies": {
-                        "wrappy": {
-                          "version": "1.0.2",
-                          "from": "wrappy@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
-                        }
-                      }
-                    },
-                    "minimatch": {
-                      "version": "3.0.4",
-                      "from": "minimatch@>=3.0.4 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-                      "dependencies": {
-                        "brace-expansion": {
-                          "version": "1.1.8",
-                          "from": "brace-expansion@>=1.1.7 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
-                          "dependencies": {
-                            "balanced-match": {
-                              "version": "1.0.0",
-                              "from": "balanced-match@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz"
-                            },
-                            "concat-map": {
-                              "version": "0.0.1",
-                              "from": "concat-map@0.0.1",
-                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "once": {
-                      "version": "1.4.0",
-                      "from": "once@>=1.3.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-                      "dependencies": {
-                        "wrappy": {
-                          "version": "1.0.2",
-                          "from": "wrappy@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
-                        }
-                      }
-                    },
-                    "path-is-absolute": {
-                      "version": "1.0.1",
-                      "from": "path-is-absolute@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
-                    }
-                  }
-                },
-                "has": {
-                  "version": "1.0.1",
-                  "from": "has@>=1.0.1 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz"
-                },
-                "inherits": {
-                  "version": "2.0.3",
-                  "from": "inherits@>=2.0.3 <2.1.0",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
-                },
-                "minimist": {
-                  "version": "1.2.0",
-                  "from": "minimist@>=1.2.0 <1.3.0",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
-                },
-                "object-inspect": {
-                  "version": "1.3.0",
-                  "from": "object-inspect@>=1.3.0 <1.4.0",
-                  "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.3.0.tgz"
-                },
-                "resolve": {
-                  "version": "1.4.0",
-                  "from": "resolve@>=1.4.0 <1.5.0",
-                  "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.4.0.tgz",
-                  "dependencies": {
-                    "path-parse": {
-                      "version": "1.0.5",
-                      "from": "path-parse@>=1.0.5 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz"
-                    }
-                  }
-                },
-                "resumer": {
-                  "version": "0.0.0",
-                  "from": "resumer@>=0.0.0 <0.1.0",
-                  "resolved": "https://registry.npmjs.org/resumer/-/resumer-0.0.0.tgz"
-                },
-                "string.prototype.trim": {
-                  "version": "1.1.2",
-                  "from": "string.prototype.trim@>=1.1.2 <1.2.0",
-                  "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.1.2.tgz",
-                  "dependencies": {
-                    "define-properties": {
-                      "version": "1.1.2",
-                      "from": "define-properties@>=1.1.2 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
-                      "dependencies": {
-                        "foreach": {
-                          "version": "2.0.5",
-                          "from": "foreach@>=2.0.5 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz"
-                        },
-                        "object-keys": {
-                          "version": "1.0.11",
-                          "from": "object-keys@>=1.0.8 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz"
-                        }
-                      }
-                    },
-                    "es-abstract": {
-                      "version": "1.8.2",
-                      "from": "es-abstract@>=1.5.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.8.2.tgz",
-                      "dependencies": {
-                        "es-to-primitive": {
-                          "version": "1.1.1",
-                          "from": "es-to-primitive@>=1.1.1 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
-                          "dependencies": {
-                            "is-date-object": {
-                              "version": "1.0.1",
-                              "from": "is-date-object@>=1.0.1 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz"
-                            },
-                            "is-symbol": {
-                              "version": "1.0.1",
-                              "from": "is-symbol@>=1.0.1 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz"
-                            }
-                          }
-                        },
-                        "is-callable": {
-                          "version": "1.1.3",
-                          "from": "is-callable@>=1.1.3 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz"
-                        },
-                        "is-regex": {
-                          "version": "1.0.4",
-                          "from": "is-regex@>=1.0.4 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "through": {
-                  "version": "2.3.8",
-                  "from": "through@>=2.3.8 <2.4.0",
-                  "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
-                }
-              }
-            },
-            "tar": {
-              "version": "2.2.1",
-              "from": "tar@>=2.2.1 <3.0.0",
-              "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-              "dependencies": {
-                "block-stream": {
-                  "version": "0.0.9",
-                  "from": "block-stream@*",
-                  "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz"
-                },
-                "fstream": {
-                  "version": "1.0.11",
-                  "from": "fstream@>=1.0.2 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
-                  "dependencies": {
-                    "graceful-fs": {
-                      "version": "4.1.11",
-                      "from": "graceful-fs@>=4.1.2 <5.0.0",
-                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
-                    }
-                  }
-                },
-                "inherits": {
-                  "version": "2.0.3",
-                  "from": "inherits@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
-                }
-              }
-            },
-            "tar-pack": {
-              "version": "3.4.0",
-              "from": "tar-pack@>=3.4.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.4.0.tgz",
-              "dependencies": {
-                "debug": {
-                  "version": "2.6.8",
-                  "from": "debug@>=2.2.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-                  "dependencies": {
-                    "ms": {
-                      "version": "2.0.0",
-                      "from": "ms@2.0.0",
-                      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
-                    }
-                  }
-                },
-                "fstream": {
-                  "version": "1.0.11",
-                  "from": "fstream@>=1.0.10 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
-                  "dependencies": {
-                    "graceful-fs": {
-                      "version": "4.1.11",
-                      "from": "graceful-fs@>=4.1.2 <5.0.0",
-                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
-                    },
-                    "inherits": {
-                      "version": "2.0.3",
-                      "from": "inherits@>=2.0.3 <2.1.0",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
-                    }
-                  }
-                },
-                "fstream-ignore": {
-                  "version": "1.0.5",
-                  "from": "fstream-ignore@>=1.0.5 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
-                  "dependencies": {
-                    "inherits": {
-                      "version": "2.0.3",
-                      "from": "inherits@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
-                    },
-                    "minimatch": {
-                      "version": "3.0.4",
-                      "from": "minimatch@>=3.0.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-                      "dependencies": {
-                        "brace-expansion": {
-                          "version": "1.1.8",
-                          "from": "brace-expansion@>=1.1.7 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
-                          "dependencies": {
-                            "balanced-match": {
-                              "version": "1.0.0",
-                              "from": "balanced-match@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz"
-                            },
-                            "concat-map": {
-                              "version": "0.0.1",
-                              "from": "concat-map@0.0.1",
-                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "once": {
-                  "version": "1.4.0",
-                  "from": "once@>=1.3.3 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.2",
-                      "from": "wrappy@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
-                    }
-                  }
-                },
-                "readable-stream": {
-                  "version": "2.3.3",
-                  "from": "readable-stream@>=2.1.4 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-                  "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.2",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                    },
-                    "inherits": {
-                      "version": "2.0.3",
-                      "from": "inherits@>=2.0.3 <2.1.0",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
-                    },
-                    "isarray": {
-                      "version": "1.0.0",
-                      "from": "isarray@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-                    },
-                    "process-nextick-args": {
-                      "version": "1.0.7",
-                      "from": "process-nextick-args@>=1.0.6 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
-                    },
-                    "safe-buffer": {
-                      "version": "5.1.1",
-                      "from": "safe-buffer@>=5.1.1 <5.2.0",
-                      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
-                    },
-                    "string_decoder": {
-                      "version": "1.0.3",
-                      "from": "string_decoder@>=1.0.3 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz"
-                    },
-                    "util-deprecate": {
-                      "version": "1.0.2",
-                      "from": "util-deprecate@>=1.0.1 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-                    }
-                  }
-                },
-                "uid-number": {
-                  "version": "0.0.6",
-                  "from": "uid-number@>=0.0.6 <0.0.7",
-                  "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz"
-                }
-              }
-            }
-          }
-        }
-      }
+    "v8-profiler-node8": {
+      "version": "6.0.1",
+      "from": "v8-profiler-node8@6.0.1",
+      "resolved": "https://registry.npmjs.org/v8-profiler-node8/-/v8-profiler-node8-6.0.1.tgz"
     },
     "validate-npm-package-license": {
       "version": "3.0.4",
@@ -5643,6 +5119,11 @@
       "from": "which-module@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
       "dev": true
+    },
+    "wide-align": {
+      "version": "1.1.3",
+      "from": "wide-align@>=1.1.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz"
     },
     "widest-line": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "redis": "~0.10.1",
     "request": "^2.79.0",
     "settings-sharelatex": "^1.1.0",
-    "v8-profiler": "^5.6.5"
+    "v8-profiler-node8": "^6.0.1"
   },
   "devDependencies": {
     "acorn": "^6.1.1",


### PR DESCRIPTION
This PR adds support for node version 8 and above.

The package used for profiling a request `v8-profiler` is not maintained anymore [1]. The package `v8-profiler-node8` [2] merged the contributions of previous upstream PRs to add support for node8 and above [3].

---
[1] Last commit is from early 2017, https://github.com/node-inspector/v8-profiler
[2] https://github.com/hyj1991/v8-profiler-node8
[3] See commit https://github.com/hyj1991/v8-profiler-node8/commit/0548b83e1871c24de4edf3c89548c114c4835f64