### PR TITLE
Removed morgan logger

### DIFF
--- a/app/js/server.js
+++ b/app/js/server.js
@@ -16,7 +16,6 @@ const Path = require('path')
 const express = require('express')
 const bodyParser = require('body-parser')
 const errorHandler = require('errorhandler')
-const morganLogger = require('morgan')
 const app = express()
 const server = require('http').createServer(app)
 const Router = require('./router')
@@ -31,7 +30,6 @@ if (app.get('env') === 'development') {
 }
 
 if (app.get('env') === 'production') {
-  app.use(morganLogger('tiny'))
   app.use(errorHandler())
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1335,14 +1335,6 @@
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
       "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
     },
-    "basic-auth": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
-      "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
-      "requires": {
-        "safe-buffer": "5.1.2"
-      }
-    },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
@@ -4568,28 +4560,6 @@
         }
       }
     },
-    "morgan": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.9.1.tgz",
-      "integrity": "sha512-HQStPIV4y3afTiCYVxirakhlCfGkI161c76kKFca7Fk1JusM//Qeo1ej2XaMniiNeaZklMVrh3vTtIzpzwbpmA==",
-      "requires": {
-        "basic-auth": "~2.0.0",
-        "debug": "2.6.9",
-        "depd": "~1.1.2",
-        "on-finished": "~2.3.0",
-        "on-headers": "~1.0.1"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
-      }
-    },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -4936,11 +4906,6 @@
       "requires": {
         "ee-first": "1.1.1"
       }
-    },
-    "on-headers": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
-      "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA=="
     },
     "once": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "logger-sharelatex": "^1.9.0",
     "metrics-sharelatex": "^2.5.0",
     "mongojs": "3.1.0",
-    "morgan": "^1.9.1",
     "request": "^2.88.2",
     "settings-sharelatex": "^1.1.0"
   },


### PR DESCRIPTION
<!-- Please review https://github.com/overleaf/write_latex/blob/master/.github/CONTRIBUTING.md for guidance on what is expected in each section. -->

### Description

`express` was updated to v4 in https://github.com/overleaf/chat/pull/39, and following [express migration guide](https://expressjs.com/en/guide/migrating-4.html) `express.logger` was replaced by `morgan`. It turns it's not needed, since the service it's already declaring `app.use(metrics.http.monitor(logger))`, which correcly forwards the appropriated logs to stack driver. 



### Review



#### Potential Impact

chat service logging




### Deployment



#### Deployment Checklist

- [x] Test chat in staging
- [x] Test chat in production
- [x] Check stackdriver logging
