### PR TITLE
[misc] get rid of unsafe Buffer usage

### DIFF
--- a/test/acceptance/js/SendingAMessageTests.js
+++ b/test/acceptance/js/SendingAMessageTests.js
@@ -179,7 +179,7 @@ describe('Sending a message', function () {
 
     return describe('with very long content', function () {
       return it('should return a graceful error', function (done) {
-        const content = new Buffer(10240).toString('hex')
+        const content = '-'.repeat(10 * 1024 + 1)
         return ChatClient.sendMessage(
           this.project_id,
           this.thread_id,


### PR DESCRIPTION
### Description

NodeJS flagged some unsafe Buffer usage while running the acceptance tests. `new Buffer(SIZE).toString()` is unsafe as it _leaks_ the previous contents of the memory area. It was too trivial to fix than leave alone and bother on every test invocation.
The payload has to be larger than [`10 * 1024`](https://github.com/overleaf/chat/blob/136779b597ed9de9c14046ecd28a15d70bb58c0c/app/js/Features/Messages/MessageHttpController.js#L24) -- I incremented it by one.

#### Potential Impact

None. Acceptance tests only.
