### PR TITLE
[misc] simplify the naming around waiting for a mongo connection

### DIFF
--- a/app.js
+++ b/app.js
@@ -23,7 +23,8 @@ if (!module.parent) {
       settings.internal != null ? settings.internal.chat : undefined,
       (x1) => x1.host
     ) || 'localhost'
-  mongodb.clientConnecting
+  mongodb
+    .waitForDb()
     .then(() => {
       Server.server.listen(port, host, function (err) {
         if (err) {

--- a/app/js/mongodb.js
+++ b/app/js/mongodb.js
@@ -1,15 +1,19 @@
 const Settings = require('settings-sharelatex')
 const { MongoClient, ObjectId } = require('mongodb')
 
-const clientConnecting = MongoClient.connect(Settings.mongo.url)
-const dbPromise = clientConnecting.then((client) => client.db())
+const clientPromise = MongoClient.connect(Settings.mongo.url)
+const dbPromise = clientPromise.then((client) => client.db())
 
 async function getCollection(name) {
   return (await dbPromise).collection(name)
 }
 
+async function waitForDb() {
+  await clientPromise
+}
+
 module.exports = {
-  clientConnecting,
   ObjectId,
-  getCollection
+  getCollection,
+  waitForDb
 }


### PR DESCRIPTION
### Description

As discussed in https://digital-science.slack.com/archives/C20TZCMMF/p1598277294014400

This PR is simplifying the naming issue with the weAreWaitingForAMongoConnectionPromise -- a Promise which resolves only after a connection to mongo has been established.

#### Related Issues / PRs

https://github.com/overleaf/issues/issues/2907
#54 

### Review

http://mongodb.github.io/node-mongodb-native/3.1/api/MongoClient.html#~connectCallback
`MongoClient.connect()` is resolving to the client instance, which makes the naming/usage non-trivial. Leveraging a `waitForDb()` wrapper -- which in turn resolves to an empty Promise -- should solve the naming issue for the use outside the mongodb module.

#### Potential Impact

High. Mongo startup may brake.

#### Manual Testing Performed

- check the mongo output -- only one connection per pod is opened
- chat works in the dev-env

#### Who Needs to Know?

Thanks for the input @emcsween @gh2k @mserranom I've tagged you a co-authors.