### PR TITLE
[misc] simplify the mongodb collection access using a shared db construct

### DIFF
--- a/app/js/mongodb.js
+++ b/app/js/mongodb.js
@@ -3,23 +3,20 @@ const { MongoClient, ObjectId } = require('mongodb')
 
 const clientPromise = MongoClient.connect(Settings.mongo.url)
 
-async function getCollection(name) {
-  return (await clientPromise).db().collection(name)
-}
-
 async function waitForDb() {
   await clientPromise
 }
 
 const db = {}
 waitForDb().then(async function () {
-  db.messages = await getCollection('messages')
-  db.rooms = await getCollection('rooms')
+  const internalDb = (await clientPromise).db()
+
+  db.messages = internalDb.collection('messages')
+  db.rooms = internalDb.collection('rooms')
 })
 
 module.exports = {
   db,
   ObjectId,
-  getCollection,
   waitForDb
 }

--- a/app/js/mongodb.js
+++ b/app/js/mongodb.js
@@ -2,10 +2,9 @@ const Settings = require('settings-sharelatex')
 const { MongoClient, ObjectId } = require('mongodb')
 
 const clientPromise = MongoClient.connect(Settings.mongo.url)
-const dbPromise = clientPromise.then((client) => client.db())
 
 async function getCollection(name) {
-  return (await dbPromise).collection(name)
+  return (await clientPromise).db().collection(name)
 }
 
 async function waitForDb() {

--- a/app/js/mongodb.js
+++ b/app/js/mongodb.js
@@ -11,7 +11,14 @@ async function waitForDb() {
   await clientPromise
 }
 
+const db = {}
+waitForDb().then(async function () {
+  db.messages = await getCollection('messages')
+  db.rooms = await getCollection('rooms')
+})
+
 module.exports = {
+  db,
   ObjectId,
   getCollection,
   waitForDb

--- a/app/js/mongodb.js
+++ b/app/js/mongodb.js
@@ -3,17 +3,21 @@ const { MongoClient, ObjectId } = require('mongodb')
 
 const clientPromise = MongoClient.connect(Settings.mongo.url)
 
+let setupDbPromise
 async function waitForDb() {
-  await clientPromise
+  if (!setupDbPromise) {
+    setupDbPromise = setupDb()
+  }
+  await setupDbPromise
 }
 
 const db = {}
-waitForDb().then(async function () {
+async function setupDb() {
   const internalDb = (await clientPromise).db()
 
   db.messages = internalDb.collection('messages')
   db.rooms = internalDb.collection('rooms')
-})
+}
 
 module.exports = {
   db,

--- a/test/acceptance/js/helpers/ChatApp.js
+++ b/test/acceptance/js/helpers/ChatApp.js
@@ -11,6 +11,7 @@
  * DS207: Consider shorter variations of null checks
  * Full docs: https://github.com/decaffeinate/decaffeinate/blob/master/docs/suggestions.md
  */
+const { waitForDb } = require('../../../../app/js/mongodb')
 const app = require('../../../../app')
 
 module.exports = {
@@ -25,9 +26,10 @@ module.exports = {
       return callback()
     } else if (this.initing) {
       return this.callbacks.push(callback)
-    } else {
-      this.initing = true
-      this.callbacks.push(callback)
+    }
+    this.initing = true
+    this.callbacks.push(callback)
+    waitForDb().then(() => {
       return app.listen(3010, 'localhost', (error) => {
         if (error != null) {
           throw error
@@ -41,6 +43,6 @@ module.exports = {
           return result
         })()
       })
-    }
+    })
   }
 }


### PR DESCRIPTION
### Description

For https://github.com/overleaf/issues/issues/2907

As discussed in https://github.com/overleaf/document-updater/pull/144#pullrequestreview-474805381 we are changing the mongo collection access again. The new approach is similar to the lazy collection access in mongojs. The [acceptance tests of the docstore service](https://github.com/overleaf/docstore/blob/dcd5bf1d6bfaff7f8f47bcfe339c7ade9601d858/test/acceptance/js/ArchiveDocsTests.js#L34-L41) are using a similar approach already -- which in turn required no/very few changes to the test-cases: https://github.com/overleaf/docstore/commit/dcd5bf1d6bfaff7f8f47bcfe339c7ade9601d858.

The access is a race-condition when looking at the module level, but app wise this is not a problem as we start the http-server from a later invoked `waitForDb()` call.

#### Review

[diff w/o white-space](https://github.com/overleaf/chat/pull/57/files?diff=unified&w=1)

#### Related Issues / PRs

https://github.com/overleaf/issues/issues/2907

#### Potential Impact

High, all mongo collection access. Covered by acceptance tests.

#### Manual Testing Performed

Run acceptance tests.
