### PR TITLE
upgrade from metrics-sharelatex to @overleaf/metrics

### DIFF
--- a/app/js/Features/Messages/MessageHttpController.js
+++ b/app/js/Features/Messages/MessageHttpController.js
@@ -13,7 +13,7 @@
  */
 let MessageHttpController
 const logger = require('logger-sharelatex')
-const metrics = require('metrics-sharelatex')
+const metrics = require('@overleaf/metrics')
 const MessageManager = require('./MessageManager')
 const MessageFormatter = require('./MessageFormatter')
 const ThreadManager = require('../Threads/ThreadManager')

--- a/app/js/Features/Messages/MessageManager.js
+++ b/app/js/Features/Messages/MessageManager.js
@@ -14,7 +14,7 @@
  */
 let MessageManager
 const { ObjectId, getCollection } = require('../../mongodb')
-const metrics = require('metrics-sharelatex')
+const metrics = require('@overleaf/metrics')
 const logger = require('logger-sharelatex')
 
 const messagesCollectionPromise = getCollection('messages')

--- a/app/js/Features/Threads/ThreadManager.js
+++ b/app/js/Features/Threads/ThreadManager.js
@@ -14,7 +14,7 @@
 let ThreadManager
 const { ObjectId, getCollection } = require('../../mongodb')
 const logger = require('logger-sharelatex')
-const metrics = require('metrics-sharelatex')
+const metrics = require('@overleaf/metrics')
 
 const roomsCollectionPromise = getCollection('rooms')
 

--- a/app/js/server.js
+++ b/app/js/server.js
@@ -8,7 +8,7 @@
  * DS102: Remove unnecessary code created because of implicit returns
  * Full docs: https://github.com/decaffeinate/decaffeinate/blob/master/docs/suggestions.md
  */
-const metrics = require('metrics-sharelatex')
+const metrics = require('@overleaf/metrics')
 metrics.initialize('chat')
 const logger = require('logger-sharelatex')
 logger.initialize('chat')

--- a/package-lock.json
+++ b/package-lock.json
@@ -761,6 +761,20 @@
         "uuid": "^3.2.1"
       }
     },
+    "@overleaf/metrics": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@overleaf/metrics/-/metrics-3.1.0.tgz",
+      "integrity": "sha512-YUtB2P6LZbk+FRXnmTX8mdiq13IJ98FvZxIKyZp77cmlF9MCAUrtf+nvatC1l5Zce8/RThU9KQBM0p0Na+Ww7g==",
+      "requires": {
+        "@google-cloud/debug-agent": "^3.0.0",
+        "@google-cloud/profiler": "^0.2.3",
+        "@google-cloud/trace-agent": "^3.2.0",
+        "compression": "^1.7.4",
+        "prom-client": "^11.1.3",
+        "underscore": "~1.6.0",
+        "yn": "^3.1.1"
+      }
+    },
     "@overleaf/o-error": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@overleaf/o-error/-/o-error-3.0.0.tgz",
@@ -1595,11 +1609,6 @@
         }
       }
     },
-    "coffee-script": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.6.0.tgz",
-      "integrity": "sha1-gIs5bhEPU9AhoZpO8fZb4OjjX6M="
-    },
     "color-convert": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
@@ -1628,6 +1637,43 @@
       "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.0.tgz",
       "integrity": "sha512-6P6g0uetGpW/sdyUy/iQQCbFF0kWVMSIVSyYz7Zgjcgh8mgw8PQzDNZeyZ5DQ2gM7LBoZPHmnjz8rUthkBG5tw==",
       "dev": true
+    },
+    "compressible": {
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
+      "integrity": "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==",
+      "requires": {
+        "mime-db": ">= 1.43.0 < 2"
+      }
+    },
+    "compression": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.4.tgz",
+      "integrity": "sha512-jaSIDzP9pZVS4ZfQ+TzvtiWhdpFhE2RDHz8QJkpX9SIpLq88VueF5jJw6t+6CUQcAoA6t+x89MLrWAqpfDE8iQ==",
+      "requires": {
+        "accepts": "~1.3.5",
+        "bytes": "3.0.0",
+        "compressible": "~2.0.16",
+        "debug": "2.6.9",
+        "on-headers": "~1.0.2",
+        "safe-buffer": "5.1.2",
+        "vary": "~1.1.2"
+      },
+      "dependencies": {
+        "bytes": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
+          "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
+        },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
     },
     "concat-map": {
       "version": "0.0.1",
@@ -3943,15 +3989,6 @@
         }
       }
     },
-    "lynx": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/lynx/-/lynx-0.1.1.tgz",
-      "integrity": "sha1-Mxjc7xaQi4KG6Bisz9sxzXQkj50=",
-      "requires": {
-        "mersenne": "~0.0.3",
-        "statsd-parser": "~0.0.4"
-      }
-    },
     "make-dir": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
@@ -4017,11 +4054,6 @@
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
       "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
     },
-    "mersenne": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/mersenne/-/mersenne-0.0.4.tgz",
-      "integrity": "sha1-QB/ex+whzbngPNPTAhOY2iGycIU="
-    },
     "messageformat": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/messageformat/-/messageformat-2.3.0.tgz",
@@ -4049,21 +4081,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
       "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
-    },
-    "metrics-sharelatex": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/metrics-sharelatex/-/metrics-sharelatex-2.5.0.tgz",
-      "integrity": "sha512-JG4yBe5bEzUW5P//8aAUoexInPosPLOXxLS4AjGxMrP78BS5PSV7uVrY0Op6b6c7ZqKItHTtEjzsUfLRPGQ/sQ==",
-      "requires": {
-        "@google-cloud/debug-agent": "^3.0.0",
-        "@google-cloud/profiler": "^0.2.3",
-        "@google-cloud/trace-agent": "^3.2.0",
-        "coffee-script": "1.6.0",
-        "lynx": "~0.1.1",
-        "prom-client": "^11.1.3",
-        "underscore": "~1.6.0",
-        "yn": "^3.1.1"
-      }
     },
     "mime": {
       "version": "2.4.4",
@@ -4544,6 +4561,11 @@
       "requires": {
         "ee-first": "1.1.1"
       }
+    },
+    "on-headers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
+      "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA=="
     },
     "once": {
       "version": "1.4.0",
@@ -6113,11 +6135,6 @@
       "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz",
       "integrity": "sha1-qPbq7KkGdMMz58Q5U/J1tFFRBpU=",
       "dev": true
-    },
-    "statsd-parser": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/statsd-parser/-/statsd-parser-0.0.4.tgz",
-      "integrity": "sha1-y9JDlTzELv/VSLXSI4jtaJ7GOb0="
     },
     "statuses": {
       "version": "1.5.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "errorhandler": "^1.5.1",
     "express": "4.17.1",
     "logger-sharelatex": "^2.2.0",
-    "metrics-sharelatex": "^2.5.0",
+    "@overleaf/metrics": "^3.1.0",
     "mongodb": "^3.6.0",
     "request": "^2.88.2",
     "settings-sharelatex": "^1.1.0"


### PR DESCRIPTION
<!-- Please review https://github.com/overleaf/write_latex/blob/master/.github/CONTRIBUTING.md for guidance on what is expected in each section. -->

### Description

This PR is to test out the upgrade  from metrics-sharelatex 2.5.0 to @overleaf/metrics 3.1.0 in chat.

The main change is that metrics is now decaffeinated.

Version 3.1.0 also enables compression for the /metrics endpoint.

If this is successful I will create an issue to roll out this change to all the other services

#### Screenshots

NA

#### Related Issues / PRs

https://github.com/overleaf/metrics-module/releases/tag/v3.1.0

https://github.com/overleaf/issues/issues/3193

### Review

Package version upgrade only.

#### Potential Impact

Metrics.

#### Manual Testing Performed

- [x] Test in local dev env (`curl --raw --compressed localhost:3010/metrics | wc -c`)

#### Accessibility

NA

### Deployment

NA

#### Deployment Checklist

NA

#### Metrics and Monitoring

Check that metrics still appear in stackdriver

#### Who Needs to Know?

@das7pad 